### PR TITLE
#include cinder/Exception.h

### DIFF
--- a/include/SpacePartitioning.h
+++ b/include/SpacePartitioning.h
@@ -26,6 +26,7 @@
 
 #include <vector>
 #include "cinder/Vector.h"
+#include "cinder/Exception.h"
 
 namespace SpacePartitioning {
 	


### PR DESCRIPTION
must have been getting included before via a pch, which isn't the case on windows (or many times in a static lib).
