### PR TITLE
silence long conversion warning from float -> uint32

### DIFF
--- a/include/sp/Grid.h
+++ b/include/sp/Grid.h
@@ -153,7 +153,7 @@ struct GridTraits<2,T,DataT> {
 	}
 	static uint32_t gridSize( const typename Grid<2,T,DataT>::vec_t &numCells )
 	{
-		return numCells.x * numCells.y;
+		return uint32_t( numCells.x * numCells.y );
 	}
 	static void rangeSearch( std::vector<typename Grid<2,T,DataT>::NodePair> *results, const typename Grid<2,T,DataT>::Vector &grid, const typename Grid<2,T,DataT>::vec_t &position, T radius, const typename Grid<2,T,DataT>::ivec_t &minCell, const typename Grid<2,T,DataT>::ivec_t &maxCell, const typename Grid<2,T,DataT>::ivec_t &numCells )
 	{


### PR DESCRIPTION
Silenced a warning that was particularly long:

```
2>D:\projects\potion\nw\blocks\SpacePartitioning\include\sp/Grid.h(156): warning C4244: 'return' : conversion from 'const float' to 'uint32_t', possible loss of data (..\..\src\nw\NodeGrid.cpp)
2>          D:\projects\potion\nw\blocks\SpacePartitioning\include\sp/Grid.h(155) : while compiling class template member function 'uint32_t SpacePartitioning::GridTraits<2,T,DataT>::gridSize(const glm::tvec2<T,0> &)'
2>          with
2>          [
2>              T=float
2>  ,            DataT=nw::NodeRef
2>          ]
2>          D:\projects\potion\nw\blocks\SpacePartitioning\include\sp/Grid.h(417) : see reference to function template instantiation 'uint32_t SpacePartitioning::GridTraits<2,T,DataT>::gridSize(const glm::tvec2<T,0> &)' being compiled
2>          with
2>          [
2>              T=float
2>  ,            DataT=nw::NodeRef
2>          ]
2>          D:\projects\potion\nw\blocks\SpacePartitioning\include\sp/Grid.h(75) : see reference to class template instantiation 'SpacePartitioning::GridTraits<2,T,DataT>' being compiled
2>          with
2>          [
2>              T=float
2>  ,            DataT=nw::NodeRef
2>          ]
2>          D:\projects\potion\nw\src\nw/NodeGrid.h(76) : see reference to class template instantiation 'SpacePartitioning::Grid<2,float,nw::NodeRef>' being compiled
```
